### PR TITLE
Add missing library call to draw_tailor_lendis.R

### DIFF
--- a/bin/draw_tailor_lendis.R
+++ b/bin/draw_tailor_lendis.R
@@ -21,6 +21,7 @@
 source (paste (Sys.getenv ("PIPELINE_DIRECTORY"),"/bin/Tailor.R",sep=""))
 pkgTest ("ggplot2")
 pkgTest ("gridExtra")
+library ("grid")
 
 argv  = commandArgs (TRUE)
 table = read.table (argv[1], F)


### PR DESCRIPTION
Without this, was getting the error:

[2016-04-12 15:35:33 EDT] Mapping the input fastq to the genome reference
[2016-04-12 15:35:35 EDT] Draw overall length distribution with tailing information
Loading required package: ggplot2
Loading required package: gridExtra
Error in arrangeGrob(...) : could not find function "textGrob"
Calls: grid.arrange -> arrangeGrob
Execution halted
[2016-04-12 15:35:37 EDT] Assigning reads to different genomic structures
